### PR TITLE
Set retention on uploaded workflow artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,5 +69,6 @@ jobs:
     - name: Upload Release Artifact
       uses: actions/upload-artifact@v4
       with:
+        retention-days: 14
         name: release-package
         path: deep-code-reasoning-mcp.tar.gz


### PR DESCRIPTION
## Summary
- set explicit retention on GitHub Actions upload-artifact steps
- keep CI/release diagnostic artifacts from falling back to repo defaults

## Test plan
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' <changed workflows>
- git diff --check
